### PR TITLE
Fix internal Link component rendering

### DIFF
--- a/src/components/link.js
+++ b/src/components/link.js
@@ -21,7 +21,7 @@ class Link extends React.Component {
 
     if (internal) {
       return (
-        <GatsbyLink to={this.props.to}>{this.props.children()}</GatsbyLink>
+        <GatsbyLink to={this.props.to}>{this.props.children}</GatsbyLink>
       )
     }
 


### PR DESCRIPTION
## Summary
- fix `Link` component by not calling children as a function

## Testing
- `npm test` *(fails: Error: no test specified)*